### PR TITLE
building improvements

### DIFF
--- a/src/main/java/Bot.java
+++ b/src/main/java/Bot.java
@@ -32,7 +32,7 @@ public class Bot extends DefaultBWListener {
     private BWClient bwClient;
     private Game game;
 
-    private GameState gameState = new GameState();
+    private GameState gameState;
 
     // TODO: Can I implement these classes as listeners and register them here? Cleans up Bot class!
     private Debug debugMap;
@@ -45,6 +45,7 @@ public class Bot extends DefaultBWListener {
     public void onStart() {
         game = bwClient.getGame();
 
+        this.gameState = new GameState(game.self());
         // Load BWEM and analyze the map
         bwem = new BWEM(game);
         bwem.initialize();

--- a/src/main/java/Debug.java
+++ b/src/main/java/Debug.java
@@ -51,8 +51,8 @@ public class Debug {
     }
 
     private void drawUnitCount() {
-        int x = 256;
-        int y = 16;
+        int x = 4;
+        int y = 128;
         game.drawTextScreen(x, y, "Unit Count");
 
         UnitTypeCount unitTypeCount = gameState.getUnitTypeCount();

--- a/src/main/java/info/GameState.java
+++ b/src/main/java/info/GameState.java
@@ -1,13 +1,14 @@
 package info;
 
+import bwapi.Player;
 import bwapi.Unit;
+import bwapi.UnitType;
 import bwem.Base;
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.Setter;
 import planner.PlannedItem;
 import strategy.openers.Opener;
-import strategy.strategies.Default;
 import strategy.strategies.Strategy;
 import strategy.strategies.UnitWeights;
 import unit.managed.ManagedUnit;
@@ -22,15 +23,21 @@ import java.util.HashSet;
  */
 @Data
 public class GameState {
+    private Player self;
+
     private int mineralWorkers;
     private int geyserWorkers;
     private int plannedSupply;
     private int larvaDeadlockDetectedFrame;
 
     private HashSet<ManagedUnit> gatherers = new HashSet<>();
+    private HashSet<ManagedUnit> mineralGatherers = new HashSet<>();
+    private HashSet<ManagedUnit> gasGatherers = new HashSet<>();
 
     private HashMap<Unit, HashSet<ManagedUnit>> geyserAssignments = new HashMap<>();
     private HashMap<Unit, HashSet<ManagedUnit>> mineralAssignments = new HashMap<>();
+
+    private HashSet<ManagedUnit> larva = new HashSet<>();
 
     private boolean enemyHasCloakedUnits = false;
     private boolean enemyHasHostileFlyers = false;
@@ -56,8 +63,11 @@ public class GameState {
 
     private TechProgression techProgression = new TechProgression();
 
-    public GameState() {
+    private ResourceCount resourceCount;
 
+    public GameState(Player self) {
+        this.self = self;
+        this.resourceCount = new ResourceCount(self);
     }
 
     public void setActiveStrategy(Strategy activeStrategy) {
@@ -67,5 +77,11 @@ public class GameState {
 
     public int numGatherers() {
         return gatherers.size();
+    }
+
+    public int numLarva() { return larva.size(); }
+
+    public int frameCanAffordUnit(UnitType unit, int currentFrame) {
+        return this.resourceCount.frameCanAffordUnit(unit, currentFrame, mineralGatherers.size(), gasGatherers.size());
     }
 }

--- a/src/main/java/info/GameState.java
+++ b/src/main/java/info/GameState.java
@@ -64,4 +64,8 @@ public class GameState {
         this.activeStrategy = activeStrategy;
         this.unitWeights = activeStrategy.getUnitWeights();
     }
+
+    public int numGatherers() {
+        return gatherers.size();
+    }
 }

--- a/src/main/java/info/ResourceCount.java
+++ b/src/main/java/info/ResourceCount.java
@@ -76,8 +76,8 @@ public class ResourceCount {
     public int frameCanAffordUnit(UnitType unit, int currentFrame, int mineralWorkers, int gasWorkers) {
         //if (this.canAffordUnit(unit)) { return currentFrame; }
 
-        final int mineralsNeeded = unit.mineralPrice() - reservedMinerals - self.minerals();
-        final int gasNeeded = unit.gasPrice() - reservedGas - self.gas();
+        final int mineralsNeeded = unit.mineralPrice() + reservedMinerals - self.minerals();
+        final int gasNeeded = unit.gasPrice() + reservedGas - self.gas();
 
         int framesToGather = 0;
         if (mineralsNeeded > 0) {

--- a/src/main/java/info/ResourceCount.java
+++ b/src/main/java/info/ResourceCount.java
@@ -1,0 +1,107 @@
+package info;
+
+import bwapi.Player;
+import bwapi.UnitType;
+import bwapi.UpgradeType;
+
+/**
+ * Tracks resources: minerals, gas and supply
+ *
+ * Used for production planning and predictions of future game state.
+ *
+ * TODO: Track supply, possibly larva?
+ */
+public class ResourceCount {
+
+    // Income prediction constants
+    // Adapted from PurpleWave: https://github.com/dgant/PurpleWave/blob/master/src/Information/Counting/Accounting.scala#L12
+    final double mineralsPerFramePerWorker = 0.044;
+    final double gasPerFramePerWorker = 0.069;
+
+    private Player self;
+    private int reservedMinerals = 0;
+    private int reservedGas = 0;
+
+    public ResourceCount(Player self) {
+        this.self = self;
+    }
+
+    public void reserveUnit(UnitType unit) {
+        this.reservedMinerals += unit.mineralPrice();
+        this.reservedGas += unit.gasPrice();
+    }
+
+    public void unreserveUnit(UnitType unit) {
+        reservedMinerals -= unit.mineralPrice();
+        reservedGas -= unit.gasPrice();
+    }
+
+    public boolean canAffordUnit(UnitType unit) {
+        final int mineralPrice = unit.mineralPrice();
+        final int gasPrice = unit.gasPrice();
+        return self.minerals() - reservedMinerals < mineralPrice || self.gas() - reservedGas < gasPrice;
+    }
+
+    public void reserveUpgrade(UpgradeType upgrade) {
+        this.reservedMinerals += upgrade.mineralPrice();
+        this.reservedGas += upgrade.gasPrice();
+    }
+
+    public void unreserveUpgrade(UpgradeType upgrade) {
+        reservedMinerals -= upgrade.mineralPrice();
+        reservedGas -= upgrade.gasPrice();
+    }
+
+    public boolean canAffordUpgrade(UpgradeType upgrade) {
+        final int mineralPrice = upgrade.mineralPrice();
+        final int gasPrice = upgrade.gasPrice();
+        return self.minerals() - reservedMinerals < mineralPrice || self.gas() - reservedGas < gasPrice;
+    }
+
+    public boolean canAffordHatch(int plannedHatcheries) {
+        return self.minerals() - reservedMinerals > ((1 + plannedHatcheries) * 300);
+    }
+
+    /**
+     * Predict the frame when the unit can be built.
+     *
+     * Return a frame in the infinite future if resource need cannot be met.
+     *
+     * @param unit unitType
+     * @param currentFrame game's current frame
+     * @param mineralWorkers number of workers on minerals
+     * @param gasWorkers number of workers on gas
+     * @return frame when all resources will be available
+     */
+    public int frameCanAffordUnit(UnitType unit, int currentFrame, int mineralWorkers, int gasWorkers) {
+        //if (this.canAffordUnit(unit)) { return currentFrame; }
+
+        final int mineralsNeeded = unit.mineralPrice() - reservedMinerals - self.minerals();
+        final int gasNeeded = unit.gasPrice() - reservedGas - self.gas();
+
+        int framesToGather = 0;
+        if (mineralsNeeded > 0) {
+            if (mineralWorkers == 0) { return Integer.MAX_VALUE; }
+            double mineralsPerFrame = mineralsPerFramePerWorker * mineralWorkers;
+            int neededFrames = (int) Math.round(mineralsNeeded / mineralsPerFrame);
+            if (neededFrames > framesToGather) {
+                framesToGather = neededFrames;
+            }
+        }
+        if (gasNeeded > 0) {
+            if (gasWorkers == 0) { return Integer.MAX_VALUE; }
+            double gasPerFrame = gasPerFramePerWorker * gasWorkers;
+            int neededFrames = (int) Math.round(gasNeeded / gasPerFrame);
+            if (neededFrames > framesToGather) {
+                framesToGather = neededFrames;
+            }
+        }
+
+        // Buffer by 10 frames
+        return currentFrame + framesToGather + 10;
+    }
+
+    public int frameCanAffordUpgrade() {
+        return 0;
+    }
+}

--- a/src/main/java/info/TechProgression.java
+++ b/src/main/java/info/TechProgression.java
@@ -5,9 +5,54 @@ import lombok.Data;
 @Data
 public class TechProgression {
 
+    // Buildings
     private boolean spawningPool = false;
     private boolean hydraliskDen = false;
     private boolean lair = false;
     private boolean spire = false;
+
+    // Planned Buildings
+    private boolean plannedSpawningPool = false;
+    private boolean plannedDen = false;
+    private boolean plannedLair = false;
+    private boolean plannedSpire = false;
+
+    // Upgrades
+    private boolean metabolicBoost = false;
+    private boolean muscularAugments = false;
+    private boolean groovedSpines = false;
+
+    // Planned Upgrades
+    private boolean plannedMetabolicBoost = false;
+    private boolean plannedMuscularAugments = false;
+    private boolean plannedGroovedSpines = false;
+
+    public boolean canPlanPool() {
+        return !plannedSpawningPool && !spawningPool;
+    }
+
+    public boolean canPlanHydraliskDen() {
+        return spawningPool && !plannedDen && !hydraliskDen;
+    }
+
+    public boolean canPlanLair() {
+        return spawningPool && !plannedLair && !lair;
+    }
+
+    public boolean canPlanSpire() {
+        return lair && !plannedSpire && spire;
+    }
+
+    public boolean canPlanMetabolicBoost() {
+        return spawningPool && !plannedMetabolicBoost && !metabolicBoost;
+    }
+
+    public boolean canPlanMuscularAugments() {
+        return hydraliskDen && !plannedMuscularAugments && !muscularAugments;
+    }
+
+    public boolean canPlanGroovedSpines() {
+        return hydraliskDen && !plannedGroovedSpines && !groovedSpines;
+    }
 
 }

--- a/src/main/java/info/TechProgression.java
+++ b/src/main/java/info/TechProgression.java
@@ -40,7 +40,7 @@ public class TechProgression {
     }
 
     public boolean canPlanSpire() {
-        return lair && !plannedSpire && spire;
+        return lair && !plannedSpire && !spire;
     }
 
     public boolean canPlanMetabolicBoost() {

--- a/src/main/java/macro/ProductionManager.java
+++ b/src/main/java/macro/ProductionManager.java
@@ -512,6 +512,7 @@ public class ProductionManager {
     private boolean canScheduleUnit(UnitType unitType) {
         TechProgression techProgression = gameState.getTechProgression();
 
+        final boolean hasFourOrMoreDrones = gameState.numGatherers() > 3;
         switch(unitType) {
             case Zerg_Overlord:
             case Zerg_Drone:
@@ -519,10 +520,10 @@ public class ProductionManager {
             case Zerg_Zergling:
                 return hasPlannedPool || techProgression.isSpawningPool();
             case Zerg_Hydralisk:
-                return hasPlannedDen || techProgression.isHydraliskDen();
+                return hasFourOrMoreDrones && (hasPlannedDen || techProgression.isHydraliskDen());
             case Zerg_Mutalisk:
             case Zerg_Scourge:
-                return hasPlannedSpire || techProgression.isSpire();
+                return hasFourOrMoreDrones && (hasPlannedSpire || techProgression.isSpire());
             default:
                 return false;
         }

--- a/src/main/java/planner/PlannedItem.java
+++ b/src/main/java/planner/PlannedItem.java
@@ -21,6 +21,7 @@ public class PlannedItem {
     private int priority;
     private int frameStart;
     private int retries = 0;
+    private int predictedReadyFrame = 0;
 
     // Block other plannedItem types in the queue
     private boolean blockOtherPlans;

--- a/src/main/java/strategy/strategies/Mutalisk.java
+++ b/src/main/java/strategy/strategies/Mutalisk.java
@@ -7,9 +7,9 @@ public class Mutalisk implements Strategy {
 
     public UnitWeights getUnitWeights() {
         UnitWeights weights = new UnitWeights();
-        weights.setWeight(UnitType.Zerg_Zergling, 0.1);
-        weights.setWeight(UnitType.Zerg_Mutalisk, 0.8);
-        weights.setWeight(UnitType.Zerg_Scourge, 0.1);
+        weights.setWeight(UnitType.Zerg_Zergling, 0.3);
+        weights.setWeight(UnitType.Zerg_Mutalisk, 0.7);
+        weights.setWeight(UnitType.Zerg_Scourge, 0.0);
         return weights;
     }
 

--- a/src/main/java/unit/WorkerManager.java
+++ b/src/main/java/unit/WorkerManager.java
@@ -2,6 +2,7 @@ package unit;
 
 import bwapi.Game;
 import bwapi.Player;
+import bwapi.Position;
 import bwapi.Text;
 import bwapi.TilePosition;
 import bwapi.Unit;
@@ -32,9 +33,11 @@ public class WorkerManager {
 
     private HashSet<ManagedUnit> assignedManagedWorkers = new HashSet<>();
     private HashSet<ManagedUnit> gatherers;
-    private HashSet<ManagedUnit> mineralGatherers = new HashSet<>();
-    private HashSet<ManagedUnit> larva = new HashSet<>();
+    private HashSet<ManagedUnit> mineralGatherers;
+    private HashSet<ManagedUnit> gasGatherers;
+    private HashSet<ManagedUnit> larva;
     private HashSet<ManagedUnit> eggs = new HashSet<>();
+    private HashSet<ManagedUnit> scheduledDrones = new HashSet<>();
 
     // Overlord takes 16 frames to hatch from egg
     // Buffered w/ 10 additional frames
@@ -44,6 +47,9 @@ public class WorkerManager {
         this.game = game;
         this.gameState = gameState;
         this.gatherers = gameState.getGatherers();
+        this.larva = gameState.getLarva();
+        this.mineralGatherers = gameState.getMineralGatherers();
+        this.gasGatherers = gameState.getGasGatherers();
     }
 
     public void onFrame() {
@@ -51,6 +57,7 @@ public class WorkerManager {
         handleLarvaDeadlock();
 
         assignScheduledPlannedItems();
+        executeScheduledDrones();
     }
 
     public void onUnitComplete(ManagedUnit managedUnit) {
@@ -190,6 +197,34 @@ public class WorkerManager {
         gameState.setPlansScheduled(scheduledPlans.stream().collect(Collectors.toCollection(HashSet::new)));
     }
 
+    // TODO: Consider acceleration, more complex paths
+    private int getTravelFrames(Unit unit, Position buildingPosition) {
+        Position unitPosition = unit.getPosition();
+        double distance = buildingPosition.getDistance(unitPosition);
+        double unitSpeed = unit.getType().topSpeed();
+
+        return (int)( distance / unitSpeed );
+    }
+
+    private void executeScheduledDrones() {
+        final int currentFrame = game.getFrameCount();
+        List<ManagedUnit> executed = new ArrayList<>();
+        for (ManagedUnit managedUnit: scheduledDrones) {
+            PlannedItem plan = managedUnit.getPlannedItem();
+            // TODO: Set build position for all scheduled build plans
+            int travelFrames = this.getTravelFrames(managedUnit.getUnit(), plan.getBuildPosition().toPosition());
+            if (currentFrame > plan.getPredictedReadyFrame() - travelFrames) {
+                plan.setState(PlanState.BUILDING);
+                managedUnit.setRole(UnitRole.BUILD);
+                executed.add(managedUnit);
+            }
+        }
+
+        for (ManagedUnit managedUnit: executed) {
+            scheduledDrones.remove(managedUnit);
+        }
+    }
+
     private void clearAssignments(ManagedUnit managedUnit) {
         if (assignedManagedWorkers.contains(managedUnit)) {
             for (HashSet<ManagedUnit> mineralWorkers: gameState.getMineralAssignments().values()) {
@@ -210,6 +245,7 @@ public class WorkerManager {
         larva.remove(managedUnit);
         gatherers.remove(managedUnit);
         mineralGatherers.remove(managedUnit);
+        gasGatherers.remove(managedUnit);
         assignedManagedWorkers.remove(managedUnit);
 
         for (HashSet<ManagedUnit> managedUnitAssignments: gameState.getGatherersAssignedToBase().values()) {
@@ -291,20 +327,31 @@ public class WorkerManager {
                 gameState.setGeyserWorkers(gameState.getGeyserWorkers()+1);
                 geyserUnits.add(managedUnit);
                 gatherers.add(managedUnit);
+                gasGatherers.add(managedUnit);
                 assignToClosestBase(geyser, managedUnit);
                 break;
             }
         }
     }
 
+    // TODO: Estimate current income and time for unit to reach build position.
+    // If expected income exceeds cost at arrival frame, assign drone
+    //
+
+    /**
+     * Assign a drone to the building plan if it's not carrying resources, not mining gas and not already assigned to a plan
+     * The unit will store a scheduled plan until it's time to execute
+     * @param plannedItem plan to build
+     * @return
+     */
     private boolean assignMorphDrone(PlannedItem plannedItem) {
         for (ManagedUnit managedUnit : assignedManagedWorkers) {
             Unit unit = managedUnit.getUnit();
-            if (unit.canBuild(plannedItem.getPlannedUnit()) && !gameState.getAssignedPlannedItems().containsKey(unit)) {
+            if (!unit.isCarrying() && !gasGatherers.contains(managedUnit) && !gameState.getAssignedPlannedItems().containsKey(unit)) {
                 clearAssignments(managedUnit);
-                plannedItem.setState(PlanState.BUILDING);
-                managedUnit.setRole(UnitRole.BUILD);
-                managedUnit.setPlannedItem(plannedItem);
+                // TODO: PlannedItem and UnitRole have a state change IN agent inside of manager
+                scheduledDrones.add(managedUnit);
+                managedUnit.setPlan(plannedItem);
                 gameState.getAssignedPlannedItems().put(unit, plannedItem);
                 return true;
             }
@@ -318,10 +365,10 @@ public class WorkerManager {
             Unit unit = managedUnit.getUnit();
             // If larva and not assigned, assign
             if (!gameState.getAssignedPlannedItems().containsKey(unit)) {
-                //clearAssignments(managedUnit);
+                clearAssignments(managedUnit);
                 plannedItem.setState(PlanState.BUILDING);
                 managedUnit.setRole(UnitRole.MORPH);
-                managedUnit.setPlannedItem(plannedItem);
+                managedUnit.setPlan(plannedItem);
                 gameState.getAssignedPlannedItems().put(unit, plannedItem);
                 return true;
             }
@@ -433,7 +480,7 @@ public class WorkerManager {
             // TODO: Handle cancelled items. Are they requeued?
             if (plannedItem != null) {
                 plannedItem.setState(PlanState.CANCELLED);
-                managedUnit.setPlannedItem(null);
+                managedUnit.setPlan(null);
             }
 
             gameState.getAssignedPlannedItems().remove(unit);

--- a/src/main/java/unit/WorkerManager.java
+++ b/src/main/java/unit/WorkerManager.java
@@ -129,7 +129,7 @@ public class WorkerManager {
         }
 
         for (ManagedUnit managedUnit: mineralGatherers) {
-            if (newGeyserWorkers.size() >= 2) {
+            if (newGeyserWorkers.size() >= 3) {
                 break;
             }
             newGeyserWorkers.add(managedUnit);

--- a/src/main/java/unit/managed/ManagedUnit.java
+++ b/src/main/java/unit/managed/ManagedUnit.java
@@ -81,6 +81,10 @@ public class ManagedUnit {
         return unitID == u.getUnitID();
     }
 
+    public void setPlan(PlannedItem plan) {
+        this.plannedItem = plan;
+    }
+
     public void execute() {
         debugRole();
 

--- a/src/main/java/unit/managed/ManagedUnit.java
+++ b/src/main/java/unit/managed/ManagedUnit.java
@@ -232,7 +232,7 @@ public class ManagedUnit {
             plannedItem.setBuildPosition(buildLocation);
         }
 
-        Position buildTarget = plannedItem.getBuildPosition().toPosition();
+        Position buildTarget = plannedItem.getBuildPosition().toPosition().add(new Position(4,4));
         if (unit.getDistance(buildTarget) > 150 || (!unit.isMoving() || unit.isGatheringMinerals())) {
             setUnready();
             unit.move(buildTarget);

--- a/src/main/java/unit/managed/ManagedUnitInterface.java
+++ b/src/main/java/unit/managed/ManagedUnitInterface.java
@@ -1,8 +1,12 @@
 package unit.managed;
 
+import planner.PlannedItem;
+
 public interface ManagedUnitInterface {
 
     UnitRole getRole();
+
+    void setPlan(PlannedItem plan);
 
     void setRole();
 


### PR DESCRIPTION
- Predict frame when resources are available for a building plan.
- Send drone to build plan location to arrive at the predicted frame, accounting for naïve travel time. 
- Refactor ProductionManager state into ResourceCount class
- Refactor ProductionManager conditional checks into TechProgression
- Adjust move target for drones moving to building location. 
- Don't pull units holding resources to build.
- Don't pull gas gatherers to build.
- Adjust Mutalisk strategy weights 