### PR TITLE
fix: overpool builds correct number of drones

### DIFF
--- a/src/main/java/strategy/buildorder/opener/Overpool.java
+++ b/src/main/java/strategy/buildorder/opener/Overpool.java
@@ -54,12 +54,12 @@ public class Overpool extends BuildOrder {
         int overlordCount = gameState.ourUnitCount(UnitType.Zerg_Overlord);
         int zerglingCount     = gameState.ourUnitCount(UnitType.Zerg_Zergling);
 
-        if (droneCount < 8 && gameState.canPlanDrone()) {
+        if (droneCount < 9 && gameState.canPlanDrone()) {
             plans.add(planUnit(gameState, UnitType.Zerg_Drone));
             return plans;
         }
 
-        if (droneCount > 7 && overlordCount < 2) {
+        if (droneCount > 8 && overlordCount < 2) {
             plans.add(planUnit(gameState, UnitType.Zerg_Overlord));
             return plans;
         }

--- a/src/main/java/strategy/buildorder/protoss/ThreeHatchMuta.java
+++ b/src/main/java/strategy/buildorder/protoss/ThreeHatchMuta.java
@@ -60,7 +60,7 @@ public class ThreeHatchMuta extends ProtossBase {
         boolean wantThird    = plannedAndCurrentHatcheries < 3 && droneCount > 13 && techProgression.isSpawningPool();
 
         // Lair timing
-        boolean wantLair = gameState.canPlanLair() && lairCount < 1 && time.greaterThan(new Time (3, 20));
+        boolean wantLair = gameState.canPlanLair() && lairCount < 1 && time.greaterThan(new Time (2, 30)) && baseCount >= 2;
 
         // Spire timing
         boolean wantSpire = techProgression.canPlanSpire() && spireCount < 1 && supply >= 64 && lairCount >= 1 && droneCount >= 16;

--- a/src/main/java/strategy/buildorder/terran/TwoHatchMuta.java
+++ b/src/main/java/strategy/buildorder/terran/TwoHatchMuta.java
@@ -63,7 +63,7 @@ public class TwoHatchMuta extends TerranBase {
         boolean wantThird    = plannedAndCurrentHatcheries < 3 && spireCount > 0 && mutaCount > 5;
 
         // Lair timing
-        boolean wantLair = gameState.canPlanLair() && lairCount < 1 && (hatchCount >= 2 || droneCount >= 12);
+        boolean wantLair = gameState.canPlanLair() && lairCount < 1 && baseCount >= 2;
 
         // Spire timing
         boolean wantSpire = techProgression.canPlanSpire() && spireCount < 1 && lairCount >= 1 && droneCount >= 16;


### PR DESCRIPTION
- ensure 2 base before lair in ZvT and ZvP