### PR TITLE
fix(IA-219): use techProgression for hydra den check in zergling suppression

### DIFF
--- a/src/main/java/strategy/buildorder/protoss/ThreeHatchHydra.java
+++ b/src/main/java/strategy/buildorder/protoss/ThreeHatchHydra.java
@@ -370,7 +370,7 @@ public class ThreeHatchHydra extends ProtossBase {
 
     @Override
     protected int zerglingsNeeded(GameState gameState) {
-        final boolean den = gameState.ourUnitCount(UnitType.Zerg_Hydralisk_Den) > 0;
+        final boolean den = gameState.getTechProgression().isHydraliskDen();
         final int hydras = gameState.ourUnitCount(UnitType.Zerg_Hydralisk);
         if (den && hydras < 11) {
             return 0;

--- a/src/main/java/strategy/buildorder/terran/ThreeHatchLurker.java
+++ b/src/main/java/strategy/buildorder/terran/ThreeHatchLurker.java
@@ -324,7 +324,7 @@ public class ThreeHatchLurker extends TerranBase {
 
     @Override
     protected int zerglingsNeeded(GameState gameState) {
-        final boolean den = gameState.ourUnitCount(UnitType.Zerg_Hydralisk_Den) > 0;
+        final boolean den = gameState.getTechProgression().isHydraliskDen();
         final int hydras = gameState.ourUnitCount(UnitType.Zerg_Hydralisk);
         
         if (den && hydras < 3) {


### PR DESCRIPTION
## Summary
- `ThreeHatchHydra.zerglingsNeeded()` used `ourUnitCount(Zerg_Hydralisk_Den)` which includes planned (queued) units, causing zergling suppression to fire as soon as the den was planned rather than when it was actually morphing
- Replaced with `techProgression.isHydraliskDen()` which only becomes true when the den starts morphing, aligning with the hydra planning gate that already uses the same check