### PR TITLE
feat(IA-205): implement defiler spell casting

### DIFF
--- a/src/main/java/info/InformationManager.java
+++ b/src/main/java/info/InformationManager.java
@@ -164,6 +164,7 @@ public class InformationManager {
         tp.setAnabolicSynthesis(self.getUpgradeLevel(UpgradeType.Anabolic_Synthesis) > 0);
         tp.setAdrenalGlands(self.getUpgradeLevel(UpgradeType.Adrenal_Glands) > 0);
         tp.setConsume(self.hasResearched(TechType.Consume));
+        tp.setPlague(self.hasResearched(TechType.Plague));
 
         tp.setCarapaceUpgrades(self.getUpgradeLevel(UpgradeType.Zerg_Carapace));
         tp.setMeleeUpgrades(self.getUpgradeLevel(UpgradeType.Zerg_Melee_Attacks));

--- a/src/main/java/info/TechProgression.java
+++ b/src/main/java/info/TechProgression.java
@@ -43,6 +43,7 @@ public class TechProgression {
     private boolean anabolicSynthesis = false;
     private boolean adrenalGlands = false;
     private boolean consume = false;
+    private boolean plague = false;
     private boolean plannedOverlordSpeed = false;
 
     // Planned Upgrades
@@ -59,6 +60,7 @@ public class TechProgression {
     private boolean plannedAnabolicSynthesis = false;
     private boolean plannedAdrenalGlands = false;
     private boolean plannedConsume = false;
+    private boolean plannedPlague = false;
 
     public boolean canPlanSunkenColony() {
         return spawningPool;
@@ -118,6 +120,10 @@ public class TechProgression {
 
     public boolean canPlanConsume() {
         return defilerMound && !plannedConsume && !consume;
+    }
+
+    public boolean canPlanPlague() {
+        return defilerMound && !plannedPlague && !plague;
     }
 
     public boolean canPlanMetabolicBoost() {

--- a/src/main/java/macro/ProductionManager.java
+++ b/src/main/java/macro/ProductionManager.java
@@ -255,6 +255,7 @@ public class ProductionManager {
             case Lurker_Aspect:
                 return UnitType.Zerg_Hydralisk_Den;
             case Consume:
+            case Plague:
                 return UnitType.Zerg_Defiler_Mound;
             default:
                 return null;
@@ -459,6 +460,7 @@ public class ProductionManager {
             case Lurker_Aspect:
                 return techProgression.isHydraliskDen();
             case Consume:
+            case Plague:
                 return techProgression.isDefilerMound();
             default:
                 return false;

--- a/src/main/java/strategy/buildorder/BuildOrder.java
+++ b/src/main/java/strategy/buildorder/BuildOrder.java
@@ -357,6 +357,10 @@ public abstract class BuildOrder {
             techProgression.setPlannedConsume(true);
         }
 
+        if (techType == TechType.Plague) {
+            techProgression.setPlannedPlague(true);
+        }
+
         return new TechPlan(techType, priority, true);
     }
 

--- a/src/main/java/strategy/buildorder/terran/CrazyZerg.java
+++ b/src/main/java/strategy/buildorder/terran/CrazyZerg.java
@@ -82,7 +82,7 @@ public class CrazyZerg extends TerranBase {
         boolean wantQueensNest = gameState.canPlanQueensNest() && extractorCount >= 3;
         boolean wantHive = gameState.canPlanHive();
         boolean wantUltraliskCavern = gameState.canPlanUltraliskCavern();
-        boolean wantDefilerMound = false;
+        boolean wantDefilerMound = techProgression.canPlanDefilerMound() && extractorCount >= 4;
 
         boolean wantMetabolicBoost = techProgression.canPlanMetabolicBoost() && hasLairOrHive;
         boolean wantCarapace = techProgression.canPlanCarapaceUpgrades() && techProgression.getEvolutionChambers() > 0;
@@ -94,7 +94,8 @@ public class CrazyZerg extends TerranBase {
         boolean wantChitinousPlating = techProgression.canPlanChitinousPlating();
         boolean wantAnabolicSynthesis = techProgression.canPlanAnabolicSynthesis()
                 && techProgression.isChitinousPlating();
-        boolean wantConsume = false;
+        boolean wantConsume = techProgression.canPlanConsume();
+        boolean wantPlague = techProgression.canPlanPlague();
         boolean wantAdrenalGlands = techProgression.canPlanAdrenalGlands();
         boolean wantOverlordSpeed = needOverlordSpeed(gameState) && techProgression.canPlanOverlordSpeed();
 
@@ -217,6 +218,11 @@ public class CrazyZerg extends TerranBase {
         if (wantConsume) {
             Plan consumePlan = this.planTech(gameState, TechType.Consume);
             plans.add(consumePlan);
+        }
+
+        if (wantPlague) {
+            Plan plaguePlan = this.planTech(gameState, TechType.Plague);
+            plans.add(plaguePlan);
         }
 
         if (wantAdrenalGlands) {

--- a/src/main/java/unit/managed/Defiler.java
+++ b/src/main/java/unit/managed/Defiler.java
@@ -184,13 +184,12 @@ public class Defiler extends ManagedUnit {
 
         if (nearbyEnemies.isEmpty()) return false;
 
-        List<Unit> engagedMelee = friendlyMelee.stream()
-                .filter(m -> nearbyEnemies.stream().anyMatch(e -> m.getDistance(e) <= SAFE_DISTANCE))
-                .collect(Collectors.toList());
+        boolean meleeEngaged = friendlyMelee.stream()
+                .anyMatch(m -> nearbyEnemies.stream().anyMatch(e -> m.getDistance(e) <= SAFE_DISTANCE));
 
-        if (engagedMelee.isEmpty()) return false;
+        if (!meleeEngaged) return false;
 
-        Position castPosition = centroid(engagedMelee);
+        Position castPosition = centroid(nearbyEnemies);
 
         for (Unit existing : game.getAllUnits()) {
             if (existing.getType() == UnitType.Spell_Dark_Swarm) {

--- a/src/main/java/unit/managed/Defiler.java
+++ b/src/main/java/unit/managed/Defiler.java
@@ -78,7 +78,6 @@ public class Defiler extends ManagedUnit {
                 .stream()
                 .filter(u -> u.getPlayer() == game.self())
                 .filter(u -> u.getType() == UnitType.Zerg_Zergling)
-                .filter(Unit::exists)
                 .collect(Collectors.toList());
 
         if (candidates.isEmpty()) return false;
@@ -113,6 +112,7 @@ public class Defiler extends ManagedUnit {
                 .stream()
                 .filter(u -> u.getPlayer().isEnemy(game.self()))
                 .filter(u -> u.isDetected() && !u.isPlagued())
+                .filter(u -> !u.getType().isBuilding() || util.Filter.isHostileBuilding(u.getType()))
                 .collect(Collectors.toList());
 
         if (enemies.isEmpty()) return false;
@@ -143,7 +143,7 @@ public class Defiler extends ManagedUnit {
         }
 
         if (bestTarget != null) {
-            unit.useTech(TechType.Plague, bestTarget.getPosition());
+            unit.useTech(TechType.Plague, bestTarget);
             castLockoutUntilFrame = game.getFrameCount() + CAST_LOCKOUT_FRAMES;
             return true;
         }
@@ -184,11 +184,9 @@ public class Defiler extends ManagedUnit {
 
         Position castPosition = centroid(nearbyEnemies);
 
-        for (Unit existing : game.getAllUnits()) {
+        for (Unit existing : game.getUnitsInRadius(castPosition, DARK_SWARM_RADIUS)) {
             if (existing.getType() == UnitType.Spell_Dark_Swarm) {
-                if (castPosition.getDistance(existing.getPosition()) < DARK_SWARM_RADIUS) {
-                    return false;
-                }
+                return false;
             }
         }
         unit.useTech(TechType.Dark_Swarm, castPosition);
@@ -211,13 +209,10 @@ public class Defiler extends ManagedUnit {
     }
 
     private void moveToSafePosition() {
-        List<Unit> nearbyEnemies = getEnemiesInRadius(unit.getX(), unit.getY());
-        if (!nearbyEnemies.isEmpty()) {
-            Position retreatPos = getSimpleRetreatPosition();
-            if (retreatPos != null) {
-                unit.move(retreatPos);
-                return;
-            }
+        Position retreatPos = getSimpleRetreatPosition();
+        if (retreatPos != null) {
+            unit.move(retreatPos);
+            return;
         }
 
         if (fightTarget != null && fightTarget.exists()) {

--- a/src/main/java/unit/managed/Defiler.java
+++ b/src/main/java/unit/managed/Defiler.java
@@ -58,11 +58,6 @@ public class Defiler extends ManagedUnit {
         unit.move(containPosition);
     }
 
-    @Override
-    protected void retreat() {
-        super.retreat();
-    }
-
     private boolean tryCastSpells() {
         if (unit.getSpellCooldown() > 0) return false;
 
@@ -72,7 +67,7 @@ public class Defiler extends ManagedUnit {
         if (enemyRace == Race.Protoss) {
             if (energy >= PLAGUE_ENERGY && tryPlague()) return true;
             if (energy >= DARK_SWARM_ENERGY && tryDarkSwarm()) return true;
-            if (energy < DARK_SWARM_ENERGY && tryConsume()) return true;
+            if (energy < PLAGUE_ENERGY && tryConsume()) return true;
         } else {
             if (energy < DARK_SWARM_ENERGY && tryConsume()) return true;
             if (energy >= DARK_SWARM_ENERGY && tryDarkSwarm()) return true;
@@ -104,12 +99,9 @@ public class Defiler extends ManagedUnit {
             }
         }
 
-        if (closest != null) {
-            unit.useTech(TechType.Consume, closest);
-            castLockoutUntilFrame = game.getFrameCount() + CAST_LOCKOUT_FRAMES;
-            return true;
-        }
-        return false;
+        unit.useTech(TechType.Consume, closest);
+        castLockoutUntilFrame = game.getFrameCount() + CAST_LOCKOUT_FRAMES;
+        return true;
     }
 
     private boolean tryPlague() {
@@ -185,17 +177,15 @@ public class Defiler extends ManagedUnit {
 
         if (engagedMelee.isEmpty()) return false;
 
+        Position castPosition = centroid(engagedMelee);
+
         for (Unit existing : game.getAllUnits()) {
             if (existing.getType() == UnitType.Spell_Dark_Swarm) {
-                Position swarmPos = existing.getPosition();
-                Position candidatePos = centroid(engagedMelee);
-                if (candidatePos.getDistance(swarmPos) < DARK_SWARM_RADIUS) {
+                if (castPosition.getDistance(existing.getPosition()) < DARK_SWARM_RADIUS) {
                     return false;
                 }
             }
         }
-
-        Position castPosition = centroid(engagedMelee);
         unit.useTech(TechType.Dark_Swarm, castPosition);
         castLockoutUntilFrame = game.getFrameCount() + CAST_LOCKOUT_FRAMES;
         return true;

--- a/src/main/java/unit/managed/Defiler.java
+++ b/src/main/java/unit/managed/Defiler.java
@@ -66,9 +66,9 @@ public class Defiler extends ManagedUnit {
         Race enemyRace = game.enemy().getRace();
 
         if (enemyRace == Race.Protoss) {
+            if (energy < PLAGUE_ENERGY && tryConsume()) return true;
             if (energy >= PLAGUE_ENERGY && tryPlague()) return true;
             if (energy >= DARK_SWARM_ENERGY && tryDarkSwarm()) return true;
-            if (energy < PLAGUE_ENERGY && tryConsume()) return true;
         } else {
             if (energy < DARK_SWARM_ENERGY && tryConsume()) return true;
             if (energy >= DARK_SWARM_ENERGY && tryDarkSwarm()) return true;
@@ -129,14 +129,16 @@ public class Defiler extends ManagedUnit {
 
         for (Unit candidate : enemies) {
             int nearbyCount = 0;
+            int splashHp = 0;
             for (Unit other : enemies) {
                 if (candidate.getDistance(other) <= PLAGUE_SPLASH_RADIUS) {
                     nearbyCount++;
+                    splashHp += other.getHitPoints();
                 }
             }
 
             boolean highValue = isHighValuePlagueTarget(candidate.getType());
-            int score = nearbyCount;
+            int score = splashHp / 50 + nearbyCount;
             if (highValue) score += 3;
 
             if (nearbyCount >= 2 || highValue) {
@@ -156,11 +158,13 @@ public class Defiler extends ManagedUnit {
     }
 
     private boolean isHighValuePlagueTarget(UnitType type) {
-        return type == UnitType.Protoss_Carrier
+        return type == UnitType.Terran_Marine
                 || type == UnitType.Terran_Battlecruiser
-                || type == UnitType.Terran_Siege_Tank_Siege_Mode
-                || type == UnitType.Terran_Siege_Tank_Tank_Mode
-                || type == UnitType.Protoss_Archon;
+                || type == UnitType.Terran_Science_Vessel
+                || type == UnitType.Zerg_Mutalisk
+                || type == UnitType.Protoss_Carrier
+                || type == UnitType.Protoss_Reaver
+                || type == UnitType.Protoss_Dragoon;
     }
 
     private boolean tryDarkSwarm() {

--- a/src/main/java/unit/managed/Defiler.java
+++ b/src/main/java/unit/managed/Defiler.java
@@ -1,11 +1,240 @@
 package unit.managed;
 
 import bwapi.Game;
+import bwapi.Position;
+import bwapi.Race;
+import bwapi.TechType;
 import bwapi.Unit;
+import bwapi.UnitType;
 import info.map.GameMap;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 public class Defiler extends ManagedUnit {
+    private static final int DARK_SWARM_ENERGY = 100;
+    private static final int PLAGUE_ENERGY = 150;
+    private static final int SAFE_DISTANCE = 256;
+    private static final int SPELL_RANGE = 288;
+    private static final int CONSUME_RANGE = 64;
+    private static final int CAST_LOCKOUT_FRAMES = 36;
+    private static final int PLAGUE_SPLASH_RADIUS = 64;
+    private static final int DARK_SWARM_RADIUS = 192;
+
+    private int castLockoutUntilFrame = 0;
+
     public Defiler(Game game, Unit unit, UnitRole role, GameMap gameMap) {
         super(game, unit, role, gameMap);
+    }
+
+    @Override
+    protected void fight() {
+        if (game.getFrameCount() < castLockoutUntilFrame) return;
+        setUnready(6);
+
+        if (tryCastSpells()) return;
+        moveToSafePosition();
+    }
+
+    @Override
+    protected void contain() {
+        if (containPosition == null) {
+            role = UnitRole.IDLE;
+            return;
+        }
+
+        if (game.getFrameCount() >= castLockoutUntilFrame) {
+            setUnready(6);
+            if (tryCastSpells()) return;
+        }
+
+        if (unit.getDistance(containPosition) < 24) {
+            setUnready(6);
+            unit.holdPosition();
+            return;
+        }
+
+        setUnready(6);
+        unit.move(containPosition);
+    }
+
+    @Override
+    protected void retreat() {
+        super.retreat();
+    }
+
+    private boolean tryCastSpells() {
+        if (unit.getSpellCooldown() > 0) return false;
+
+        int energy = unit.getEnergy();
+        Race enemyRace = game.enemy().getRace();
+
+        if (enemyRace == Race.Protoss) {
+            if (energy >= PLAGUE_ENERGY && tryPlague()) return true;
+            if (energy >= DARK_SWARM_ENERGY && tryDarkSwarm()) return true;
+            if (energy < DARK_SWARM_ENERGY && tryConsume()) return true;
+        } else {
+            if (energy < DARK_SWARM_ENERGY && tryConsume()) return true;
+            if (energy >= DARK_SWARM_ENERGY && tryDarkSwarm()) return true;
+            if (energy >= PLAGUE_ENERGY && tryPlague()) return true;
+        }
+
+        return false;
+    }
+
+    private boolean tryConsume() {
+        if (!game.self().hasResearched(TechType.Consume)) return false;
+
+        List<Unit> candidates = game.getUnitsInRadius(unit.getPosition(), CONSUME_RANGE)
+                .stream()
+                .filter(u -> u.getPlayer() == game.self())
+                .filter(u -> u.getType() == UnitType.Zerg_Zergling)
+                .filter(Unit::exists)
+                .collect(Collectors.toList());
+
+        if (candidates.isEmpty()) return false;
+
+        Unit closest = null;
+        double closestDist = Double.MAX_VALUE;
+        for (Unit candidate : candidates) {
+            double d = unit.getDistance(candidate);
+            if (d < closestDist) {
+                closestDist = d;
+                closest = candidate;
+            }
+        }
+
+        if (closest != null) {
+            unit.useTech(TechType.Consume, closest);
+            castLockoutUntilFrame = game.getFrameCount() + CAST_LOCKOUT_FRAMES;
+            return true;
+        }
+        return false;
+    }
+
+    private boolean tryPlague() {
+        if (!game.self().hasResearched(TechType.Plague)) return false;
+
+        List<Unit> enemies = game.getUnitsInRadius(unit.getPosition(), SPELL_RANGE)
+                .stream()
+                .filter(u -> u.getPlayer().isEnemy(game.self()))
+                .filter(u -> u.isDetected() && !u.isPlagued())
+                .collect(Collectors.toList());
+
+        if (enemies.isEmpty()) return false;
+
+        Unit bestTarget = null;
+        int bestScore = 0;
+
+        for (Unit candidate : enemies) {
+            int nearbyCount = 0;
+            for (Unit other : enemies) {
+                if (candidate.getDistance(other) <= PLAGUE_SPLASH_RADIUS) {
+                    nearbyCount++;
+                }
+            }
+
+            boolean highValue = isHighValuePlagueTarget(candidate.getType());
+            int score = nearbyCount;
+            if (highValue) score += 3;
+
+            if (nearbyCount >= 2 || highValue) {
+                if (score > bestScore) {
+                    bestScore = score;
+                    bestTarget = candidate;
+                }
+            }
+        }
+
+        if (bestTarget != null) {
+            unit.useTech(TechType.Plague, bestTarget.getPosition());
+            castLockoutUntilFrame = game.getFrameCount() + CAST_LOCKOUT_FRAMES;
+            return true;
+        }
+        return false;
+    }
+
+    private boolean isHighValuePlagueTarget(UnitType type) {
+        return type == UnitType.Protoss_Carrier
+                || type == UnitType.Terran_Battlecruiser
+                || type == UnitType.Terran_Siege_Tank_Siege_Mode
+                || type == UnitType.Terran_Siege_Tank_Tank_Mode
+                || type == UnitType.Protoss_Archon;
+    }
+
+    private boolean tryDarkSwarm() {
+        List<Unit> friendlyMelee = game.getUnitsInRadius(unit.getPosition(), SPELL_RANGE)
+                .stream()
+                .filter(u -> u.getPlayer() == game.self())
+                .filter(u -> isMeleeType(u.getType()))
+                .collect(Collectors.toList());
+
+        if (friendlyMelee.isEmpty()) return false;
+
+        List<Unit> nearbyEnemies = game.getUnitsInRadius(unit.getPosition(), SPELL_RANGE)
+                .stream()
+                .filter(u -> u.getPlayer().isEnemy(game.self()))
+                .filter(u -> u.isDetected() && !u.isUnderDarkSwarm())
+                .collect(Collectors.toList());
+
+        if (nearbyEnemies.isEmpty()) return false;
+
+        List<Unit> engagedMelee = friendlyMelee.stream()
+                .filter(m -> nearbyEnemies.stream().anyMatch(e -> m.getDistance(e) <= SAFE_DISTANCE))
+                .collect(Collectors.toList());
+
+        if (engagedMelee.isEmpty()) return false;
+
+        for (Unit existing : game.getAllUnits()) {
+            if (existing.getType() == UnitType.Spell_Dark_Swarm) {
+                Position swarmPos = existing.getPosition();
+                Position candidatePos = centroid(engagedMelee);
+                if (candidatePos.getDistance(swarmPos) < DARK_SWARM_RADIUS) {
+                    return false;
+                }
+            }
+        }
+
+        Position castPosition = centroid(engagedMelee);
+        unit.useTech(TechType.Dark_Swarm, castPosition);
+        castLockoutUntilFrame = game.getFrameCount() + CAST_LOCKOUT_FRAMES;
+        return true;
+    }
+
+    private boolean isMeleeType(UnitType type) {
+        return type == UnitType.Zerg_Zergling || type == UnitType.Zerg_Ultralisk;
+    }
+
+    private Position centroid(List<Unit> units) {
+        int sumX = 0;
+        int sumY = 0;
+        for (Unit u : units) {
+            sumX += u.getX();
+            sumY += u.getY();
+        }
+        return new Position(sumX / units.size(), sumY / units.size());
+    }
+
+    private void moveToSafePosition() {
+        List<Unit> nearbyEnemies = getEnemiesInRadius(unit.getX(), unit.getY());
+        if (!nearbyEnemies.isEmpty()) {
+            Position retreatPos = getSimpleRetreatPosition();
+            if (retreatPos != null) {
+                unit.move(retreatPos);
+                return;
+            }
+        }
+
+        if (fightTarget != null && fightTarget.exists()) {
+            double distance = unit.getDistance(fightTarget);
+            if (distance > SPELL_RANGE) {
+                unit.move(fightTarget.getPosition());
+                return;
+            }
+        }
+
+        if (rallyPoint != null) {
+            unit.move(rallyPoint);
+        }
     }
 }

--- a/src/main/java/unit/managed/Defiler.java
+++ b/src/main/java/unit/managed/Defiler.java
@@ -16,7 +16,8 @@ public class Defiler extends ManagedUnit {
     private static final int PLAGUE_ENERGY = 150;
     private static final int SAFE_DISTANCE = 256;
     private static final int SPELL_RANGE = 288;
-    private static final int CONSUME_RANGE = 64;
+    private static final int CONSUME_CAST_RANGE = 32;
+    private static final int CONSUME_SEARCH_RANGE = 256;
     private static final int CAST_LOCKOUT_FRAMES = 36;
     private static final int PLAGUE_SPLASH_RADIUS = 64;
     private static final int DARK_SWARM_RADIUS = 192;
@@ -80,7 +81,7 @@ public class Defiler extends ManagedUnit {
     private boolean tryConsume() {
         if (!game.self().hasResearched(TechType.Consume)) return false;
 
-        List<Unit> candidates = game.getUnitsInRadius(unit.getPosition(), CONSUME_RANGE)
+        List<Unit> candidates = game.getUnitsInRadius(unit.getPosition(), CONSUME_SEARCH_RANGE)
                 .stream()
                 .filter(u -> u.getPlayer() == game.self())
                 .filter(u -> u.getType() == UnitType.Zerg_Zergling)
@@ -99,8 +100,16 @@ public class Defiler extends ManagedUnit {
             }
         }
 
-        unit.useTech(TechType.Consume, closest);
-        castLockoutUntilFrame = game.getFrameCount() + CAST_LOCKOUT_FRAMES;
+        if (closestDist <= CONSUME_CAST_RANGE) {
+            unit.useTech(TechType.Consume, closest);
+            castLockoutUntilFrame = game.getFrameCount() + CAST_LOCKOUT_FRAMES;
+            return true;
+        }
+
+        List<Unit> nearbyEnemies = getEnemiesInRadius(unit.getX(), unit.getY());
+        if (!nearbyEnemies.isEmpty()) return false;
+
+        unit.move(closest.getPosition());
         return true;
     }
 

--- a/src/main/java/unit/managed/Defiler.java
+++ b/src/main/java/unit/managed/Defiler.java
@@ -2,7 +2,6 @@ package unit.managed;
 
 import bwapi.Game;
 import bwapi.Position;
-import bwapi.Race;
 import bwapi.TechType;
 import bwapi.Unit;
 import bwapi.UnitType;
@@ -63,17 +62,11 @@ public class Defiler extends ManagedUnit {
         if (unit.getSpellCooldown() > 0) return false;
 
         int energy = unit.getEnergy();
-        Race enemyRace = game.enemy().getRace();
+        int consumeThreshold = game.self().hasResearched(TechType.Plague) ? PLAGUE_ENERGY : DARK_SWARM_ENERGY;
 
-        if (enemyRace == Race.Protoss) {
-            if (energy < PLAGUE_ENERGY && tryConsume()) return true;
-            if (energy >= PLAGUE_ENERGY && tryPlague()) return true;
-            if (energy >= DARK_SWARM_ENERGY && tryDarkSwarm()) return true;
-        } else {
-            if (energy < DARK_SWARM_ENERGY && tryConsume()) return true;
-            if (energy >= DARK_SWARM_ENERGY && tryDarkSwarm()) return true;
-            if (energy >= PLAGUE_ENERGY && tryPlague()) return true;
-        }
+        if (energy < consumeThreshold && tryConsume()) return true;
+        if (energy >= PLAGUE_ENERGY && tryPlague()) return true;
+        if (energy >= DARK_SWARM_ENERGY && tryDarkSwarm()) return true;
 
         return false;
     }

--- a/src/main/java/unit/squad/SquadManager.java
+++ b/src/main/java/unit/squad/SquadManager.java
@@ -683,6 +683,11 @@ public class SquadManager {
             return;
         }
 
+        if (squad.isGroundSquad() && squad.hasOnly(UnitType.Zerg_Defiler)) {
+            rallySquad(squad);
+            return;
+        }
+
         Set<Position> stormPositions = gameState.getActiveStormPositions();
         if (!stormPositions.isEmpty()) {
             boolean anyUnitInStorm = false;

--- a/src/main/java/unit/squad/SquadManager.java
+++ b/src/main/java/unit/squad/SquadManager.java
@@ -1297,7 +1297,9 @@ public class SquadManager {
             if (nearestEnemy != null) {
                 managedUnit.setFightTarget(nearestEnemy);
             } else {
-                managedUnit.setMovementTargetPosition(gameState.pollScoutTarget());
+                managedUnit.setFightTarget(null);
+                managedUnit.setRallyPoint(squad.getCenter());
+                managedUnit.setRole(UnitRole.RALLY);
             }
             return;
         }

--- a/src/main/java/unit/squad/SquadManager.java
+++ b/src/main/java/unit/squad/SquadManager.java
@@ -1282,6 +1282,25 @@ public class SquadManager {
             }
             return;
         }
+        if (managedUnit.getUnitType() == UnitType.Zerg_Defiler) {
+            Set<Unit> enemies = gameState.getVisibleEnemyUnits();
+            Unit nearestEnemy = null;
+            double nearestDistance = Double.MAX_VALUE;
+            for (Unit enemyUnit : enemies) {
+                if (!enemyUnit.isDetected()) continue;
+                double d = unit.getDistance(enemyUnit);
+                if (d < nearestDistance) {
+                    nearestDistance = d;
+                    nearestEnemy = enemyUnit;
+                }
+            }
+            if (nearestEnemy != null) {
+                managedUnit.setFightTarget(nearestEnemy);
+            } else {
+                managedUnit.setMovementTargetPosition(gameState.pollScoutTarget());
+            }
+            return;
+        }
         List<Unit> enemyUnits = new ArrayList<>();
         enemyUnits.addAll(gameState.getVisibleEnemyUnits());
 


### PR DESCRIPTION
## Summary

- Implement Defiler spell-casting AI with Dark Swarm, Plague, and Consume spells. Matchup-specific priority: ZvP prefers Plague first, ZvT prefers Consume first. Includes cast lockout to prevent double-casting during latency frames.
- Enable Defiler production in CrazyZerg build order when 4+ gas bases are taken. Add Plague research tracking across the production pipeline (TechProgression, InformationManager, ProductionManager, BuildOrder).
- Fix SquadManager target assignment for weaponless Defilers — assigns nearest visible enemy as fight target instead of sending them to scout targets.