### PR TITLE
fix(IA-220): demote non-threatening hostile buildings to normal priority

### DIFF
--- a/src/main/java/unit/squad/SquadManager.java
+++ b/src/main/java/unit/squad/SquadManager.java
@@ -34,9 +34,10 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import util.TargetScorer;
+
 import static java.lang.Math.min;
 import static util.Distance.manhattanTileDistance;
-import util.TargetScorer;
 
 public class SquadManager {
 
@@ -1307,8 +1308,7 @@ public class SquadManager {
             }
             return;
         }
-        List<Unit> enemyUnits = new ArrayList<>();
-        enemyUnits.addAll(gameState.getVisibleEnemyUnits());
+        List<Unit> enemyUnits = new ArrayList<>(gameState.getVisibleEnemyUnits());
 
         List<Unit> filtered = new ArrayList<>();
         for (Unit enemyUnit: enemyUnits) {

--- a/src/main/java/unit/squad/SquadManager.java
+++ b/src/main/java/unit/squad/SquadManager.java
@@ -231,8 +231,7 @@ public class SquadManager {
 
         filtered = filterByProximity(filtered, unit);
 
-        Set<Position> basePositions = gameState.getBaseData().getMyBasePositions();
-        Unit bestTarget = TargetScorer.selectTarget(unit, filtered, managedUnit.fightTarget, basePositions);
+        Unit bestTarget = TargetScorer.selectTarget(unit, filtered, managedUnit.fightTarget);
         if (bestTarget != null) {
             managedUnit.setFightTarget(bestTarget);
         }
@@ -1340,8 +1339,7 @@ public class SquadManager {
             }
         }
 
-        Set<Position> basePositions = gameState.getBaseData().getMyBasePositions();
-        Unit bestTarget = TargetScorer.selectTarget(unit, filtered, managedUnit.fightTarget, basePositions);
+        Unit bestTarget = TargetScorer.selectTarget(unit, filtered, managedUnit.fightTarget);
         if (bestTarget != null) {
             managedUnit.setFightTarget(bestTarget);
         }

--- a/src/main/java/util/Filter.java
+++ b/src/main/java/util/Filter.java
@@ -25,35 +25,6 @@ public final class Filter {
         return closestUnit;
     }
 
-    public static Unit closestHostileUnit(Unit unit, List<Unit> unitList) {
-        if (unitList.size() == 1) {
-            return unitList.get(0);
-        }
-
-        Unit closestCombat = null;
-        int closestCombatDistance = Integer.MAX_VALUE;
-        Unit closestBuilding = null;
-        int closestBuildingDistance = Integer.MAX_VALUE;
-
-        for (Unit u : unitList) {
-            UnitType type = u.getType();
-            int distance = unit.getDistance(u.getPosition());
-            if (!type.isBuilding() || isHostileBuilding(type)) {
-                if (distance < closestCombatDistance) {
-                    closestCombat = u;
-                    closestCombatDistance = distance;
-                }
-            } else {
-                if (distance < closestBuildingDistance) {
-                    closestBuilding = u;
-                    closestBuildingDistance = distance;
-                }
-            }
-        }
-
-        return closestCombat != null ? closestCombat : closestBuilding;
-    }
-
     public static boolean isHostileBuilding(UnitType unitType) {
         if (!unitType.isBuilding()) {
             return false;

--- a/src/main/java/util/TargetScorer.java
+++ b/src/main/java/util/TargetScorer.java
@@ -34,7 +34,7 @@ public final class TargetScorer {
 
         for (Unit candidate : candidates) {
             UnitType candidateType = candidate.getType();
-            Priority priority = assignPriority(candidateType, attackerIsFlying);
+            Priority priority = assignPriority(candidateType, attackerIsFlying, candidate);
             double score = scoreWithinTier(attacker, candidate, currentTarget);
 
             if (bestPriority == null
@@ -49,7 +49,7 @@ public final class TargetScorer {
         return bestTarget;
     }
 
-    private static Priority assignPriority(UnitType candidateType, boolean attackerIsFlying) {
+    private static Priority assignPriority(UnitType candidateType, boolean attackerIsFlying, Unit candidate) {
         if (candidateType.isBuilding()) {
             if (Filter.isHostileBuilding(candidateType)) {
                 boolean canHitMe = canAttackType(candidateType, attackerIsFlying);
@@ -59,6 +59,9 @@ public final class TargetScorer {
         }
 
         if (Filter.isWorkerType(candidateType)) {
+            if (Filter.isMeanWorker(candidate)) {
+                return Priority.CRITICAL;
+            }
             return Priority.ELEVATED;
         }
 

--- a/src/main/java/util/TargetScorer.java
+++ b/src/main/java/util/TargetScorer.java
@@ -14,7 +14,6 @@ public final class TargetScorer {
         LOW,
         NORMAL,
         ELEVATED,
-        HIGH,
         CRITICAL
     }
 

--- a/src/main/java/util/TargetScorer.java
+++ b/src/main/java/util/TargetScorer.java
@@ -1,17 +1,14 @@
 package util;
 
-import bwapi.Position;
 import bwapi.Unit;
 import bwapi.UnitType;
 import bwapi.WeaponType;
 
 import java.util.List;
-import java.util.Set;
 
 public final class TargetScorer {
 
     private static final double CURRENT_TARGET_BONUS = 1.2;
-    private static final int WORKER_NEAR_BASE_RADIUS = 512;
 
     private enum Priority {
         LOW,
@@ -21,7 +18,7 @@ public final class TargetScorer {
         CRITICAL
     }
 
-    public static Unit selectTarget(Unit attacker, List<Unit> candidates, Unit currentTarget, Set<Position> friendlyBasePositions) {
+    public static Unit selectTarget(Unit attacker, List<Unit> candidates, Unit currentTarget) {
         if (candidates.isEmpty()) {
             return null;
         }
@@ -37,7 +34,7 @@ public final class TargetScorer {
 
         for (Unit candidate : candidates) {
             UnitType candidateType = candidate.getType();
-            Priority priority = assignPriority(candidateType, attackerIsFlying, candidate, friendlyBasePositions);
+            Priority priority = assignPriority(candidateType, attackerIsFlying);
             double score = scoreWithinTier(attacker, candidate, currentTarget);
 
             if (bestPriority == null
@@ -52,7 +49,7 @@ public final class TargetScorer {
         return bestTarget;
     }
 
-    private static Priority assignPriority(UnitType candidateType, boolean attackerIsFlying, Unit candidate, Set<Position> friendlyBasePositions) {
+    private static Priority assignPriority(UnitType candidateType, boolean attackerIsFlying) {
         if (candidateType.isBuilding()) {
             if (Filter.isHostileBuilding(candidateType)) {
                 boolean canHitMe = canAttackType(candidateType, attackerIsFlying);
@@ -62,16 +59,7 @@ public final class TargetScorer {
         }
 
         if (Filter.isWorkerType(candidateType)) {
-            if (Filter.isMeanWorker(candidate)) {
-                return Priority.ELEVATED;
-            }
-            if (isNearFriendlyBase(candidate, friendlyBasePositions)) {
-                return Priority.ELEVATED;
-            }
-            if (attackerIsFlying) {
-                return Priority.ELEVATED;
-            }
-            return Priority.NORMAL;
+            return Priority.ELEVATED;
         }
 
         boolean canHitMe = canAttackType(candidateType, attackerIsFlying);
@@ -99,18 +87,5 @@ public final class TargetScorer {
         if (unitType == UnitType.Protoss_Carrier) return true;
         WeaponType weapon = targetIsFlying ? unitType.airWeapon() : unitType.groundWeapon();
         return weapon != null && weapon != WeaponType.None;
-    }
-
-    private static boolean isNearFriendlyBase(Unit unit, Set<Position> basePositions) {
-        if (basePositions == null || basePositions.isEmpty()) {
-            return false;
-        }
-        Position unitPos = unit.getPosition();
-        for (Position basePos : basePositions) {
-            if (unitPos.getDistance(basePos) <= WORKER_NEAR_BASE_RADIUS) {
-                return true;
-            }
-        }
-        return false;
     }
 }

--- a/src/main/java/util/TargetScorer.java
+++ b/src/main/java/util/TargetScorer.java
@@ -56,7 +56,7 @@ public final class TargetScorer {
         if (candidateType.isBuilding()) {
             if (Filter.isHostileBuilding(candidateType)) {
                 boolean canHitMe = canAttackType(candidateType, attackerIsFlying);
-                return canHitMe ? Priority.CRITICAL : Priority.ELEVATED;
+                return canHitMe ? Priority.CRITICAL : Priority.NORMAL;
             }
             return Priority.LOW;
         }


### PR DESCRIPTION
## Summary

- Rework `TargetScorer` priority tiers: workers are always ELEVATED (above non-threatening buildings), mean workers are CRITICAL, and hostile buildings that can't hit the attacker are demoted to NORMAL
- Simplify `selectTarget` API by removing unused `friendlyBasePositions` parameter
- Remove dead code: `Priority.HIGH` enum value, `Filter.closestHostileUnit()`, and `isNearFriendlyBase()` helper